### PR TITLE
add parquet as a valid file_format (to test hubData)

### DIFF
--- a/hub-config/admin.json
+++ b/hub-config/admin.json
@@ -8,7 +8,7 @@
     },
     "repository_host": "GitHub",
     "repository_url": "https://github.com/cdcepi/FluSight-forecast-hub",
-    "file_format": ["csv"],
+    "file_format": ["csv", "parquet"],
     "timezone": "US/Eastern",
     "model_output_dir": "model-output",
     "cloud": {


### PR DESCRIPTION
temporary workaround so we can use hubData against the S3 files