### PR TITLE
Revert "add parquet as a valid file_format (to test hubData)"

### DIFF
--- a/hub-config/admin.json
+++ b/hub-config/admin.json
@@ -8,7 +8,7 @@
     },
     "repository_host": "GitHub",
     "repository_url": "https://github.com/cdcepi/FluSight-forecast-hub",
-    "file_format": ["csv", "parquet"],
+    "file_format": ["csv"],
     "timezone": "US/Eastern",
     "model_output_dir": "model-output",
     "cloud": {


### PR DESCRIPTION
Reverts bsweger/FluSight-forecast-hub#2

(restoring the admin config to its original state for further testing)