### PR TITLE
explicitly use dplyr lag

### DIFF
--- a/target-data/get_target_data_hubverse.R
+++ b/target-data/get_target_data_hubverse.R
@@ -160,14 +160,14 @@ calc_oracle_output_rate_change <- function(time_series_target) {
     dplyr::group_by(.data[["location"]]) |>
     dplyr::arrange(.data[["target_end_date"]]) |>
     dplyr::mutate(
-      rate_diff0 = .data[["weekly_rate"]] - lag(.data[["weekly_rate"]], 1),
-      rate_diff1 = .data[["weekly_rate"]] - lag(.data[["weekly_rate"]], 2),
-      rate_diff2 = .data[["weekly_rate"]] - lag(.data[["weekly_rate"]], 3),
-      rate_diff3 = .data[["weekly_rate"]] - lag(.data[["weekly_rate"]], 4),
-      count_change0 = .data[["observation"]] - lag(.data[["observation"]], 1),
-      count_change1 = .data[["observation"]] - lag(.data[["observation"]], 2),
-      count_change2 = .data[["observation"]] - lag(.data[["observation"]], 3),
-      count_change3 = .data[["observation"]] - lag(.data[["observation"]], 4)
+      rate_diff0 = .data[["weekly_rate"]] - dplyr::lag(.data[["weekly_rate"]], 1),
+      rate_diff1 = .data[["weekly_rate"]] - dplyr::lag(.data[["weekly_rate"]], 2),
+      rate_diff2 = .data[["weekly_rate"]] - dplyr::lag(.data[["weekly_rate"]], 3),
+      rate_diff3 = .data[["weekly_rate"]] - dplyr::lag(.data[["weekly_rate"]], 4),
+      count_change0 = .data[["observation"]] - dplyr::lag(.data[["observation"]], 1),
+      count_change1 = .data[["observation"]] - dplyr::lag(.data[["observation"]], 2),
+      count_change2 = .data[["observation"]] - dplyr::lag(.data[["observation"]], 3),
+      count_change3 = .data[["observation"]] - dplyr::lag(.data[["observation"]], 4)
     ) |>
     dplyr::ungroup() |>
     tidyr::pivot_longer(


### PR DESCRIPTION
This is future-proofing these statements in the case the functions here are ever moved to a package. 

The `lag()` function is in the {stats} package, which is attached in R by default. It is designed to work with `ts` objects. Importantly, it does _not_ do what you expect the {dplyr} incantation to do. 

If this function is ever moved into a context where {dplyr} is not explicitly attached via `library(dplyr)`, then this function will produce results that are not lagged.